### PR TITLE
relax elixir version requirement to ~> 1.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ExProf.Mixfile do
   def project do
     [ app: :exprof,
       version: "0.1.3",
-      elixir: "~> 0.14.3 or ~> 0.15.0 or ~> 1.0.0",
+      elixir: "~> 0.14.3 or ~> 0.15.0 or ~> 1.0",
       deps: deps,
       description: description,
       package: package


### PR DESCRIPTION
- tests pass on elixir 1.1.0-dev

Not sure about including mix.lock here.  I included it for now for completeness, since it was automatically updated by mix.  I can resubmit without it.