### PR TITLE
drop support for elixir pre-1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: erlang
 env:
-  - ELIXIR="v0.14.3"
-  - ELIXIR="v0.15.0"
   - ELIXIR="v1.0.0"
 otp_release:
   - 17.1

--- a/mix.exs
+++ b/mix.exs
@@ -3,8 +3,8 @@ defmodule ExProf.Mixfile do
 
   def project do
     [ app: :exprof,
-      version: "0.1.3",
-      elixir: "~> 0.14.3 or ~> 0.15.0 or ~> 1.0",
+      version: "0.2.0",
+      elixir: "~> 1.0",
       deps: deps,
       description: description,
       package: package

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ExProf.Mixfile do
   def project do
     [ app: :exprof,
       version: "0.1.3",
-      elixir: "~> 0.14.3 or ~> 0.15.0 or ~> 1.0.0",
+      elixir: "~> 0.14.3 or ~> 0.15.0 or ~> 1.0",
       deps: deps,
       description: description,
       package: package

--- a/mix.lock
+++ b/mix.lock
@@ -1,1 +1,1 @@
-%{"exprintf": {:package, "0.1.5"}}
+%{"exprintf": {:hex, :exprintf, "0.1.5"}}


### PR DESCRIPTION
- elixir 0.14 does not support newer (> 1.0) mix.lock format