### PR TITLE
Resolve warnings on missing parantheses

### DIFF
--- a/lib/exprof.ex
+++ b/lib/exprof.ex
@@ -10,7 +10,7 @@ defmodule ExProf do
   @doc """
   Start the profiling for the specified pid.
   """
-  def start(pid \\ self) do
+  def start(pid \\ self()) do
     :eprof.start
     :eprof.start_profiling([pid])
   end

--- a/lib/exprof/analyzer.ex
+++ b/lib/exprof/analyzer.ex
@@ -25,7 +25,7 @@ defmodule ExProf.Analyzer do
   Print records to screen
   """
   def print(records) do
-    print_header
+    print_header()
     Enum.each(records, &(do_print(&1)))
   end
 

--- a/lib/exprof/macro.ex
+++ b/lib/exprof/macro.ex
@@ -16,7 +16,7 @@ defmodule ExProf.Macro do
     quote do
       pid = spawn(ExProf.Macro, :execute_profile, [fn -> unquote(code) end])
       ExProf.start(pid)
-      send pid, self
+      send pid, self()
 
       receive do
         _ -> nil

--- a/lib/sample/sample_runner.ex
+++ b/lib/sample/sample_runner.ex
@@ -11,7 +11,7 @@ defmodule SampleRunner do
 
   @doc "get analysis records and sum them up"
   def run do
-    records = do_analyze
+    records = do_analyze()
     total_percent = Enum.reduce(records, 0.0, &(&1.percent + &2))
     IO.inspect "total = #{total_percent}"
   end

--- a/mix.exs
+++ b/mix.exs
@@ -5,9 +5,9 @@ defmodule ExProf.Mixfile do
     [ app: :exprof,
       version: "0.2.0",
       elixir: "~> 1.0",
-      deps: deps,
-      description: description,
-      package: package
+      deps: deps(),
+      description: description(),
+      package: package()
     ]
   end
 


### PR DESCRIPTION
This commit resolves warnings of the following form:

```
warning: variable "do_analyze" does not exist and is being expanded to "do_analyze()", please use parentheses to remove the ambiguity or change the variable name
  lib/sample/sample_runner.ex:14
```

Tested with Elixir v1.5.1.