### PR TITLE
Link profiled process to avoid hang

### DIFF
--- a/lib/exprof/macro.ex
+++ b/lib/exprof/macro.ex
@@ -14,7 +14,7 @@ defmodule ExProf.Macro do
   """
   defmacro profile(code) do
     quote do
-      pid = spawn(ExProf.Macro, :execute_profile, [fn -> unquote(code) end])
+      pid = spawn_link(ExProf.Macro, :execute_profile, [fn -> unquote(code) end])
       ExProf.start(pid)
       send pid, self()
 

--- a/test/exprof_test.exs
+++ b/test/exprof_test.exs
@@ -10,11 +10,11 @@ defmodule ExprofTest do
 
   @tag timeout: 1000
   test "abort on exit" do
-    import ExProf.Macro
-
     Process.flag(:trap_exit, true)
 
     pid = spawn_link(fn ->
+      import ExProf.Macro
+
       profile do
         Process.exit(self(), :kill)
       end

--- a/test/exprof_test.exs
+++ b/test/exprof_test.exs
@@ -7,4 +7,19 @@ defmodule ExprofTest do
       SampleRunner.run
     end) =~ ~r/FUNCTION\s+CALLS/m
   end
+
+  @tag timeout: 1000
+  test "abort on exit" do
+    import ExProf.Macro
+
+    Process.flag(:trap_exit, true)
+
+    pid = spawn_link(fn ->
+      profile do
+        Process.exit(self(), :kill)
+      end
+    end)
+
+    assert_receive {:EXIT, ^pid, :killed}, 500
+  end
 end


### PR DESCRIPTION
If the profiled process is not linked or monitored, a crash in that
process will result in an infinite wait of `receive`.