### PR TITLE
Add :tools to extra_applications in mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,9 @@ defmodule ExProf.Mixfile do
 
   # Configuration for the OTP application
   def application do
-    []
+    [
+      extra_applications: [:tools]
+    ]
   end
 
   # Returns the list of dependencies in the format:


### PR DESCRIPTION
On Elixir 1.11, the compiler emits:
```
warning: :eprof.start_profiling/1 defined in application :tools is used by the current application but the current application does not directly depend on :tools. To fix this, you must do one of:

  1. If :tools is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

  2. If :tools is a dependency, make sure it is listed under "def deps" in your mix.exs

  3. In case you don't want to add a requirement to :tools, you may optionally skip this warning by adding [xref: [exclude: :eprof]] to your "def project" in mix.exs

  lib/exprof.ex:15: ExProf.start/1
```
This PR adds `:tools` to `extra_applications` in `mix.exs` to remove the warning.
